### PR TITLE
Minor optimization to sbi_strlen

### DIFF
--- a/lib/sbi/sbi_string.c
+++ b/lib/sbi/sbi_string.c
@@ -38,14 +38,13 @@ int sbi_strncmp(const char *a, const char *b, size_t count)
 
 size_t sbi_strlen(const char *str)
 {
-	unsigned long ret = 0;
+	const char* ostr = str;
 
 	while (*str != '\0') {
-		ret++;
 		str++;
 	}
 
-	return ret;
+	return str - ostr;
 }
 
 size_t sbi_strnlen(const char *str, size_t count)


### PR DESCRIPTION
There are algorthimically more clever ways to do strlen(), but the original implementation has a hot loop of 4 opcodes instead of 3.
This changes the per-character body from:
.L3:
	addi	a5,a5,1
	add	a4,a0,a5
	lbu	a4,0(a4)
	bne	a4,zero,.L3
to
.L3:
	lbu	a4,1(a5)
	addi	a5,a5,1
	bne	a4,zero,.L3
While keeping the source CS101 level of complexity.

strnlen() could probably benefit from a similar change...